### PR TITLE
Graylog 2.3 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.graylog.plugins</groupId>
     <artifactId>graylog-plugin-slack</artifactId>
-    <version>2.4.0</version>
+    <version>2.4.1</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <graylog2.plugin-dir>/usr/share/graylog-server/plugin</graylog2.plugin-dir>
-        <graylog2.version>2.0.0</graylog2.version>
+        <graylog2.version>2.3.0</graylog2.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/graylog2/plugins/slack/SlackPluginMetadata.java
+++ b/src/main/java/org/graylog2/plugins/slack/SlackPluginMetadata.java
@@ -34,7 +34,7 @@ public class SlackPluginMetadata implements PluginMetaData {
 
     @Override
     public Version getVersion() {
-        return Version.fromPluginProperties(this.getClass(), PLUGIN_PROPERTIES, "version", Version.from(2, 4, 0, "unknown"));
+        return Version.fromPluginProperties(this.getClass(), PLUGIN_PROPERTIES, "version", Version.from(2, 4, 1, "unknown"));
     }
 
     @Override

--- a/src/main/java/org/graylog2/plugins/slack/SlackPluginMetadata.java
+++ b/src/main/java/org/graylog2/plugins/slack/SlackPluginMetadata.java
@@ -10,6 +10,8 @@ import java.util.Collections;
 import java.util.Set;
 
 public class SlackPluginMetadata implements PluginMetaData {
+    private static final String PLUGIN_PROPERTIES = "org.graylog.plugins.graylog-plugin-slack/graylog-plugin.properties";
+
     @Override
     public String getUniqueId() {
         return SlackAlarmCallback.class.getCanonicalName();
@@ -32,7 +34,7 @@ public class SlackPluginMetadata implements PluginMetaData {
 
     @Override
     public Version getVersion() {
-        return new Version(2, 4, 0);
+        return Version.fromPluginProperties(this.getClass(), PLUGIN_PROPERTIES, "version", Version.from(2, 4, 0, "unknown"));
     }
 
     @Override
@@ -42,7 +44,7 @@ public class SlackPluginMetadata implements PluginMetaData {
 
     @Override
     public Version getRequiredVersion() {
-        return new Version(2, 0, 0);
+        return Version.fromPluginProperties(this.getClass(), PLUGIN_PROPERTIES, "graylog.version", Version..from(2, 0, 0, "unknown"));
     }
 
     @Override

--- a/src/main/java/org/graylog2/plugins/slack/SlackPluginMetadata.java
+++ b/src/main/java/org/graylog2/plugins/slack/SlackPluginMetadata.java
@@ -44,7 +44,7 @@ public class SlackPluginMetadata implements PluginMetaData {
 
     @Override
     public Version getRequiredVersion() {
-        return Version.fromPluginProperties(this.getClass(), PLUGIN_PROPERTIES, "graylog.version", Version..from(2, 0, 0, "unknown"));
+        return Version.fromPluginProperties(this.getClass(), PLUGIN_PROPERTIES, "graylog.version", Version.from(2, 0, 0, "unknown"));
     }
 
     @Override

--- a/src/main/resources/org.graylog.plugins.graylog-plugin-slack/graylog-plugin.properties
+++ b/src/main/resources/org.graylog.plugins.graylog-plugin-slack/graylog-plugin.properties
@@ -1,0 +1,12 @@
+# The plugin version
+version=${project.version}
+
+# The required Graylog server version
+graylog.version=${graylog.version}
+
+# When set to true (the default) the plugin gets a separate class loader
+# when loading the plugin. When set to false, the plugin shares a class loader
+# with other plugins that have isolated=false.
+#
+# Do not disable this unless this plugin depends on another plugin!
+isolated=false


### PR DESCRIPTION
Graylog 2.3.0 deprecated some of the methods in org.graylog2.plugin.Version.