### PR TITLE
Capitalize getName return String to "Slack Alarm Callback"

### DIFF
--- a/src/main/java/org/graylog2/plugins/slack/callback/SlackAlarmCallback.java
+++ b/src/main/java/org/graylog2/plugins/slack/callback/SlackAlarmCallback.java
@@ -153,6 +153,6 @@ public class SlackAlarmCallback extends SlackPluginBase implements AlarmCallback
 
     @Override
     public String getName() {
-        return "Slack alarm callback";
+        return "Slack Alarm Callback";
     }
 }


### PR DESCRIPTION
Capitalize first letters of the plugin name to "Slack Alarm Callback" in order to keep default notification type display name style: Email Alert Callback and HTTP Alarm Callback.