### PR TITLE
Log a direct link to the graylog message (github workaround)

### DIFF
--- a/src/main/java/org/graylog2/plugins/slack/SlackPluginBase.java
+++ b/src/main/java/org/graylog2/plugins/slack/SlackPluginBase.java
@@ -77,4 +77,13 @@ public class SlackPluginBase {
                 configuration.getBoolean(SlackConfiguration.CK_LINK_NAMES)
         );
     }
+
+    protected String buildMessageLink(String baseUrl, String index, String id) {
+        if (!baseUrl.endsWith("/")) {
+            baseUrl = baseUrl + "/";
+        }
+
+        return baseUrl + "messages/" + index + "/" + id;
+    }
+
 }

--- a/src/main/java/org/graylog2/plugins/slack/output/SlackMessageOutput.java
+++ b/src/main/java/org/graylog2/plugins/slack/output/SlackMessageOutput.java
@@ -80,16 +80,24 @@ public class SlackMessageOutput extends SlackPluginBase implements MessageOutput
         String graylogUri = configuration.getString(SlackConfiguration.CK_GRAYLOG2_URL);
         boolean notifyChannel = configuration.getBoolean(SlackConfiguration.CK_NOTIFY_CHANNEL);
 
-        String titleLink;
+        String streamLink;
         if (!isNullOrEmpty(graylogUri)) {
-            titleLink = "<" + buildStreamLink(graylogUri, stream) + "|" + stream.getTitle() + ">";
+            streamLink = "<" + buildStreamLink(graylogUri, stream) + "|" + stream.getTitle() + ">";
         } else {
-            titleLink = "_" + stream.getTitle() + "_";
+            streamLink = "_" + stream.getTitle() + "_";
+        }
+
+        String messageLink;
+        if (!isNullOrEmpty(graylogUri)) {
+            String index = "graylog_deflector"; // would use msg.getFieldAs(String.class, "_index"), but it returns null
+            messageLink = "<" + buildMessageLink(graylogUri, index, msg.getId()) + "|New message>";
+        } else {
+            messageLink = "New message";
         }
 
         String audience = notifyChannel ? "@channel " : "";
-        return String.format("%s*New message in Graylog stream %s*:\n> %s",
-                audience, titleLink, msg.getMessage());
+        return String.format("%s*%s in Graylog stream %s*:\n> %s",
+                audience, messageLink, streamLink, msg.getMessage());
     }
 
     private String buildShortMessageBody(Message msg) {


### PR DESCRIPTION
This is a duplicate pull request of #39 to work around github displaying all commits in a merge operation. Text from original pull request:

A link to the stream is useful, but it's even more useful to be able to get
directly to the message. This is especially true if you are looking at an older
message that's outside of the time window given.

This commit misses one thing: referencing the correct index. Hopefully that can
be fixed before a merge. In the meantime I'm using `graylog_deflector`, which
will the index active at the time of using the URL.

I would love some help on how to get the current index. As mentioned in the
code comment, using `msg.getFieldAs(String.class, "_index")` gave me `null`.